### PR TITLE
Fix compilation on stricter compilers.

### DIFF
--- a/src/CopyRunner.hpp
+++ b/src/CopyRunner.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <optional>
 #include <sys/types.h>
 #include <asm/types.h>
 #include <functional>


### PR DESCRIPTION
CopyRunner.hpp had a missing <optional> include that was hidden by other
C++ standard header files, until (at least!) GCC 11.1. This fixes the
build.